### PR TITLE
Subject preview

### DIFF
--- a/src/QuantityIndicator.js
+++ b/src/QuantityIndicator.js
@@ -2,9 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {withStyles} from "@material-ui/core/styles";
 import LinearProgress from "@material-ui/core/LinearProgress";
-import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
-import Tooltip from "@material-ui/core/Tooltip"
+import Tooltip from "@material-ui/core/Tooltip";
 
 
 const CustomLinearProgress = withStyles((theme) => ({

--- a/src/QuantityIndicator.js
+++ b/src/QuantityIndicator.js
@@ -5,7 +5,6 @@ import LinearProgress from "@material-ui/core/LinearProgress";
 import Typography from "@material-ui/core/Typography";
 import Box from "@material-ui/core/Box";
 import Tooltip from "@material-ui/core/Tooltip"
-import Paper from "@material-ui/core/Paper"
 
 
 const CustomLinearProgress = withStyles((theme) => ({
@@ -18,13 +17,12 @@ const CustomLinearProgress = withStyles((theme) => ({
     }
 }))(LinearProgress);
 
-const QuantityIndicator = ({value, valueSecond=0, maxValue=100, color="primary", label, tooltip, paper}) => {
+const QuantityIndicator = ({value, valueSecond=0, maxValue=100, color="primary", label, tooltip}) => {
     return (
         label ?
             <Tooltip title={tooltip}>
-            <Paper square elevation={paper ? 1 : 0}>
             <Box display="flex" alignItems="center">
-                <Box mr={1} ml={1} width={32}>
+                <Box mr={1} ml={1} width={52}>
                     {/* <Tooltip title={tooltip}>{label}</Tooltip> */}
                     {label}
                 </Box>
@@ -37,7 +35,6 @@ const QuantityIndicator = ({value, valueSecond=0, maxValue=100, color="primary",
                     />
                 </Box>
             </Box>
-            </Paper>
             </Tooltip>
         :
             <Tooltip title={tooltip}>

--- a/src/QuantityIndicator.js
+++ b/src/QuantityIndicator.js
@@ -10,12 +10,16 @@ const CustomLinearProgress = withStyles((theme) => ({
     root: {
         height: 4,
     },
-    dashed: { /* Disable dashed animation for variant="buffer" */
+    dashed: {  // Disable dashed animation for variant="buffer"
         animation: "",
         display: "none",
     }
 }))(LinearProgress);
 
+
+/**
+ * Displays a horizontal bar indicating a numerical value (optionally 2 values).
+ */
 const QuantityIndicator = ({value, valueSecond=0, valueMax, label,
                             labelWidth, tooltip, color="primary"}) => {
     return (
@@ -38,14 +42,20 @@ const QuantityIndicator = ({value, valueSecond=0, valueMax, label,
 };
 
 QuantityIndicator.propTypes = {
+    /** Main value. */
     value: PropTypes.number.isRequired,
+    /** Optional secondary value, uses a lighter shade of the color. */
     valueSecond: PropTypes.number,
+    /** Maximal value, determines the width of the component. */
     valueMax: PropTypes.number.isRequired,
-
+    /** Text label, placed on the left side. */
     label: PropTypes.string.isRequired,
+    /** Estimated width of the text label. */
     labelWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    /** Text for the tooltip. */
     tooltip: PropTypes.string.isRequired,
-    color: PropTypes.string,
+    /** Color of the bar. */
+    color: PropTypes.oneOf(["primary", "secondary"]),
 };
 
 export default QuantityIndicator;

--- a/src/QuantityIndicator.js
+++ b/src/QuantityIndicator.js
@@ -17,7 +17,7 @@ const CustomLinearProgress = withStyles((theme) => ({
     }
 }))(LinearProgress);
 
-const QuantityIndicator = ({value, valueSecond=0, valueMax=100, label,
+const QuantityIndicator = ({value, valueSecond=0, valueMax, label,
                             labelWidth, tooltip, color="primary"}) => {
     return (
         <Tooltip title={tooltip}>
@@ -39,7 +39,14 @@ const QuantityIndicator = ({value, valueSecond=0, valueMax=100, label,
 };
 
 QuantityIndicator.propTypes = {
+    value: PropTypes.number.isRequired,
+    valueSecond: PropTypes.number,
+    valueMax: PropTypes.number.isRequired,
 
+    label: PropTypes.string.isRequired,
+    labelWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    tooltip: PropTypes.string.isRequired,
+    color: PropTypes.string,
 };
 
 export default QuantityIndicator;

--- a/src/QuantityIndicator.js
+++ b/src/QuantityIndicator.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {withStyles} from "@material-ui/core/styles";
+import LinearProgress from "@material-ui/core/LinearProgress";
+import Typography from "@material-ui/core/Typography";
+import Box from "@material-ui/core/Box";
+import Tooltip from "@material-ui/core/Tooltip"
+import Paper from "@material-ui/core/Paper"
+
+
+const CustomLinearProgress = withStyles((theme) => ({
+    root: {
+        height: 4,
+    },
+    dashed: { /* Disable dashed animation for variant="buffer" */
+        animation: "",
+        display: "none",
+    }
+}))(LinearProgress);
+
+const QuantityIndicator = ({value, valueSecond=0, maxValue=100, color="primary", label, tooltip, paper}) => {
+    return (
+        label ?
+            <Tooltip title={tooltip}>
+            <Paper square elevation={paper ? 1 : 0}>
+            <Box display="flex" alignItems="center">
+                <Box mr={1} ml={1} width={32}>
+                    {/* <Tooltip title={tooltip}>{label}</Tooltip> */}
+                    {label}
+                </Box>
+                <Box width="100%">
+                    <CustomLinearProgress
+                        variant="buffer"
+                        color={color}
+                        value={100 * value / maxValue}
+                        valueBuffer={100 * (value + valueSecond) / maxValue}
+                    />
+                </Box>
+            </Box>
+            </Paper>
+            </Tooltip>
+        :
+            <Tooltip title={tooltip}>
+                <CustomLinearProgress
+                    variant="buffer"
+                    color={color}
+                    value={100 * value / maxValue}
+                    valueBuffer={100 * (value + valueSecond) / maxValue}
+                />
+            </Tooltip>
+    );
+};
+
+QuantityIndicator.propTypes = {
+
+};
+
+export default QuantityIndicator;

--- a/src/QuantityIndicator.js
+++ b/src/QuantityIndicator.js
@@ -17,34 +17,24 @@ const CustomLinearProgress = withStyles((theme) => ({
     }
 }))(LinearProgress);
 
-const QuantityIndicator = ({value, valueSecond=0, maxValue=100, color="primary", label, tooltip}) => {
+const QuantityIndicator = ({value, valueSecond=0, valueMax=100, label,
+                            labelWidth, tooltip, color="primary"}) => {
     return (
-        label ?
-            <Tooltip title={tooltip}>
-            <Box display="flex" alignItems="center">
-                <Box mr={1} ml={1} width={52}>
-                    {/* <Tooltip title={tooltip}>{label}</Tooltip> */}
-                    {label}
-                </Box>
-                <Box width="100%">
-                    <CustomLinearProgress
-                        variant="buffer"
-                        color={color}
-                        value={100 * value / maxValue}
-                        valueBuffer={100 * (value + valueSecond) / maxValue}
-                    />
-                </Box>
+        <Tooltip title={tooltip}>
+        <Box display="flex" alignItems="center">
+            <Box width={labelWidth} mr={1} textAlign="right">
+                {label}
             </Box>
-            </Tooltip>
-        :
-            <Tooltip title={tooltip}>
+            <Box width="100%">
                 <CustomLinearProgress
                     variant="buffer"
                     color={color}
-                    value={100 * value / maxValue}
-                    valueBuffer={100 * (value + valueSecond) / maxValue}
+                    value={100 * value / valueMax}
+                    valueBuffer={100 * (value + valueSecond) / valueMax}
                 />
-            </Tooltip>
+            </Box>
+        </Box>
+        </Tooltip>
     );
 };
 

--- a/src/SubjectPreview.js
+++ b/src/SubjectPreview.js
@@ -1,44 +1,217 @@
 import React from 'react';
-import ListItemText from "@material-ui/core/ListItemText";
-import SubjectDialog from "./SubjectDialog";
-import Typography from "@material-ui/core/Typography";
+import PropTypes from 'prop-types';
+import {makeStyles} from "@material-ui/core/styles";
 import ListItem from "@material-ui/core/ListItem";
+import ListItemText from "@material-ui/core/ListItemText";
+import Typography from "@material-ui/core/Typography";
+import Grid from "@material-ui/core/Grid";
+
+import Box from "@material-ui/core/Box";
+import Paper from "@material-ui/core/Paper";
+import Tooltip from "@material-ui/core/Tooltip";
+import Divider from "@material-ui/core/Divider";
+
+import SubjectDialog from "./SubjectDialog";
+import QuantityIndicator from "./QuantityIndicator"
 import {daysInWeek} from "./constants";
+
+import HourglassEmptyOutlined from "@material-ui/icons/HourglassEmptyOutlined"
+import CakeOutlined from "@material-ui/icons/CakeOutlined"
+
 
 const formatDay = (day) => {
     return daysInWeek[day];
 }
 
+
+const useStyles = makeStyles((theme) => ({
+    root: {},
+}));
+
+
+// TODO Temporary
+const paper = false
+
 /** Assigned to Jan */
-// TODO ListItem does not have to be used, you may delete anything/rewrite it however you want
-// TODO note that ListItem is expected to be child of List, which it currently is in ResultsList.js
-const SubjectPreview = ({subject}) => {
+const SubjectPreview = ({subject, variant}) => {
+    const classes = useStyles()
+
+    // TODO Temporary hacks
+    subject.name = "Průmyslový vývoj software"
+
     return (
+        <React.Fragment>
         <ListItem key={subject.code}>
-            <ListItemText
+            <Typography component="div" variant="body2" color="textSecondary">
+            {/* <ListItemText
                 component="div"
-                primary={<SubjectDialog subject={subject}/>}
-                secondary={
-                    <React.Fragment>
-                        <Typography
-                            component="span"
-                            variant="body2"
-                            color="textPrimary"
-                        >
-                            {subject.code}
-                        </Typography>
-                        {" — " + subject.lecturer}
-                        <br />
-                        <Typography
-                            component="span"
-                            variant="body2"
-                        >
-                            {"Rozvrhováno: " + formatDay(subject.day)}
-                        </Typography>
-                    </React.Fragment>
-                }/>
+                primary={
+                    <SubjectDialog subject={subject}/>
+                }
+                /> */}
+            {subject.day <= 2 ?
+            <Grid container spacing={0} justify="space-between">
+                <Grid item xs={12} sm={12}>
+                    <Typography component="div" variant="body1">
+                    <SubjectDialog subject={subject}/>
+                    </Typography>
+                </Grid>
+                <Grid item xs={10} sm={6}>
+                    <ItemFirstLine subject={subject}/>
+                </Grid>
+                <Grid item xs={2} sm={1}>
+                    <ItemExamType subject={subject}/>
+                </Grid>
+                <Grid item xs={6} sm={2}>
+                    <ItemCredits subject={subject} useBar/>
+                </Grid>
+                <Grid item xs={6} sm={2}>
+                    <ItemHours subject={subject} useBar/>
+                </Grid>
+
+                <Grid item xs={12} sm={12}>
+                    <ItemTimetable subject={subject}/>
+                </Grid>
+
+                <Grid item xs={12} sm={12}>
+                    <ItemAnnotation subject={subject}/>
+                </Grid>
+            </Grid>
+            : subject.day <= 4 ?
+            <Grid container spacing={0} justify="space-between">
+                <Grid item xs={12} sm={12}>
+                    <Typography component="div" variant="body1">
+                    <SubjectDialog subject={subject}/>
+                    </Typography>
+                </Grid>
+                <Grid container item xs={12} sm={9} spacing={1} justify="space-between">
+                    <Grid item xs={10} sm={6}>
+                        <ItemFirstLine subject={subject}/>
+                    </Grid>
+                    <Grid item xs={6} sm={6}>
+                        <ItemTimetable subject={subject} align="right"/>
+                    </Grid>
+
+                    <Grid item xs={9} sm={12}>
+                        <ItemAnnotation subject={subject}/>
+                    </Grid>
+                </Grid>
+                <Grid container item xs={12} sm={3} spacing={1}>
+                    <Grid item xs={12}>
+                        <ItemExamType subject={subject}/>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <ItemCredits subject={subject} useBar/>
+                    </Grid>
+                    <Grid item xs={12}>
+                        <ItemHours subject={subject} useBar/>
+                    </Grid>
+                </Grid>
+            </Grid>
+            : "unknown variant"}
+            </Typography>
         </ListItem>
+        {/* <Divider component="li"/> */}
+        </React.Fragment>
     );
 };
 
+SubjectPreview.propTypes = {
+
+};
+
 export default SubjectPreview;
+
+
+// TODO Probably should move these definitions somewhere else in the future
+const ItemFirstLine = ({subject}) => {
+    return (
+        <Typography variant="body2" gutterBottom>
+            <Typography component="span" variant="body2" color="textPrimary">
+                {"18" + subject.code}
+            </Typography>
+            {" — " + "KSI" + " — " + subject.lecturer}
+        </Typography>
+    );
+};
+
+
+const ItemExamType = ({subject}) => {
+    return (
+        <Paper square elevation={paper ? 1 : 0}>
+        <Box ml={1}>
+            <Typography variant="body2" color="textSecondary" align="center" component="span">{"z zk"}</Typography>
+        </Box>
+        </Paper>
+    );
+};
+
+
+const ItemTimetable = ({subject, align="left"}) => {
+    return (
+        <Typography variant="body2" align={align} gutterBottom>
+            {"Rozvrhováno: "}{formatDay(subject.day)}
+            {subject.day === 4 ? ", úterý" : null}
+            {subject.day === 1 ? ", pátek" : null}
+        </Typography>
+    );
+};
+
+
+const ItemAnnotation = ({subject}) => {
+    return (
+        <Typography variant="body2" align="justify">
+            /anotace/ Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+            sed do eiusmod tempor incididunt ut labore et dolore magna
+            aliqua. Ut enim ad minim veniam, quis...
+        </Typography>
+    );
+};
+
+
+const ItemCredits = ({subject, useBar}) => {
+    return(
+        useBar ?
+        <QuantityIndicator
+            value={3}
+            maxValue={12}
+            tooltip={
+                // "kredity"
+                "3 kredity"
+            }
+            label={
+                // <Typography variant="body2" color="textSecondary" align="right">{"3"}</Typography>
+                // <CakeOutlined fontSize="small"/>
+                <Typography variant="body2" color="textSecondary" align="right" component="span">{"kr"}</Typography>
+            }
+            paper={paper}
+        />
+        :
+        <Typography variant="body2" color="textSecondary" align="right">{"3 kr"}</Typography>
+    );
+};
+
+
+const ItemHours = ({subject, useBar}) => {
+    return(
+        useBar ?
+        <QuantityIndicator
+            value={Number(subject.length)}
+            valueSecond={2}
+            maxValue={12}
+            color="secondary"
+            tooltip={
+                // "hodiny p+cv"
+                "2h přednášky + 2h cvičení"
+            }
+            label={
+                // <Typography variant="body2" color="textSecondary" align="right">{"2+2"}</Typography>
+                // <HourglassEmptyOutlined fontSize="small"/>
+                <Typography variant="body2" color="textSecondary" align="right" component="span">{"h"}</Typography>
+            }
+            paper={paper}
+        />
+        :
+        <Typography variant="body2" color="textSecondary" align="right">{"2+2 h"}</Typography>
+    );
+};

--- a/src/SubjectPreview.js
+++ b/src/SubjectPreview.js
@@ -3,20 +3,13 @@ import PropTypes from 'prop-types';
 import {makeStyles} from "@material-ui/core/styles";
 import ListItem from "@material-ui/core/ListItem";
 import ListItemText from "@material-ui/core/ListItemText";
-import Typography from "@material-ui/core/Typography";
-import Grid from "@material-ui/core/Grid";
-
 import Box from "@material-ui/core/Box";
-import Paper from "@material-ui/core/Paper";
-import Tooltip from "@material-ui/core/Tooltip";
-import Divider from "@material-ui/core/Divider";
+import Grid from "@material-ui/core/Grid";
+import Typography from "@material-ui/core/Typography";
 
 import SubjectDialog from "./SubjectDialog";
 import QuantityIndicator from "./QuantityIndicator"
 import {daysInWeek} from "./constants";
-
-import HourglassEmptyOutlined from "@material-ui/icons/HourglassEmptyOutlined"
-import CakeOutlined from "@material-ui/icons/CakeOutlined"
 
 
 const formatDay = (day) => {
@@ -29,61 +22,19 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 
-// TODO Temporary
-const paper = false
-
 /** Assigned to Jan */
-const SubjectPreview = ({subject, variant}) => {
+const SubjectPreview = ({subject}) => {
     const classes = useStyles()
 
     // TODO Temporary hacks
     subject.name = "Průmyslový vývoj software"
 
     return (
-        <React.Fragment>
-        <ListItem key={subject.code}>
+        <ListItem key={subject.code} style={{display: "block"}}>
+            <ListItemText primary={<SubjectDialog subject={subject}/>}/>
+
             <Typography component="div" variant="body2" color="textSecondary">
-            {/* <ListItemText
-                component="div"
-                primary={
-                    <SubjectDialog subject={subject}/>
-                }
-                /> */}
-            {subject.day <= 2 ?
             <Grid container spacing={0} justify="space-between">
-                <Grid item xs={12} sm={12}>
-                    <Typography component="div" variant="body1">
-                    <SubjectDialog subject={subject}/>
-                    </Typography>
-                </Grid>
-                <Grid item xs={10} sm={6}>
-                    <ItemFirstLine subject={subject}/>
-                </Grid>
-                <Grid item xs={2} sm={1}>
-                    <ItemExamType subject={subject}/>
-                </Grid>
-                <Grid item xs={6} sm={2}>
-                    <ItemCredits subject={subject} useBar/>
-                </Grid>
-                <Grid item xs={6} sm={2}>
-                    <ItemHours subject={subject} useBar/>
-                </Grid>
-
-                <Grid item xs={12} sm={12}>
-                    <ItemTimetable subject={subject}/>
-                </Grid>
-
-                <Grid item xs={12} sm={12}>
-                    <ItemAnnotation subject={subject}/>
-                </Grid>
-            </Grid>
-            : subject.day <= 4 ?
-            <Grid container spacing={0} justify="space-between">
-                <Grid item xs={12} sm={12}>
-                    <Typography component="div" variant="body1">
-                    <SubjectDialog subject={subject}/>
-                    </Typography>
-                </Grid>
                 <Grid container item xs={12} sm={9} spacing={1} justify="space-between">
                     <Grid item xs={10} sm={6}>
                         <ItemFirstLine subject={subject}/>
@@ -108,11 +59,8 @@ const SubjectPreview = ({subject, variant}) => {
                     </Grid>
                 </Grid>
             </Grid>
-            : "unknown variant"}
             </Typography>
         </ListItem>
-        {/* <Divider component="li"/> */}
-        </React.Fragment>
     );
 };
 
@@ -138,11 +86,9 @@ const ItemFirstLine = ({subject}) => {
 
 const ItemExamType = ({subject}) => {
     return (
-        <Paper square elevation={paper ? 1 : 0}>
         <Box ml={1}>
             <Typography variant="body2" color="textSecondary" align="center" component="span">{"z zk"}</Typography>
         </Box>
-        </Paper>
     );
 };
 
@@ -169,49 +115,31 @@ const ItemAnnotation = ({subject}) => {
 };
 
 
-const ItemCredits = ({subject, useBar}) => {
+const ItemCredits = ({subject}) => {
     return(
-        useBar ?
         <QuantityIndicator
             value={3}
             maxValue={12}
-            tooltip={
-                // "kredity"
-                "3 kredity"
-            }
+            tooltip={"3 kredity"}
             label={
-                // <Typography variant="body2" color="textSecondary" align="right">{"3"}</Typography>
-                // <CakeOutlined fontSize="small"/>
                 <Typography variant="body2" color="textSecondary" align="right" component="span">{"kr"}</Typography>
             }
-            paper={paper}
         />
-        :
-        <Typography variant="body2" color="textSecondary" align="right">{"3 kr"}</Typography>
     );
 };
 
 
-const ItemHours = ({subject, useBar}) => {
+const ItemHours = ({subject}) => {
     return(
-        useBar ?
         <QuantityIndicator
             value={Number(subject.length)}
             valueSecond={2}
             maxValue={12}
             color="secondary"
-            tooltip={
-                // "hodiny p+cv"
-                "2h přednášky + 2h cvičení"
-            }
+            tooltip={"2h přednášky + 2h cvičení"}
             label={
-                // <Typography variant="body2" color="textSecondary" align="right">{"2+2"}</Typography>
-                // <HourglassEmptyOutlined fontSize="small"/>
                 <Typography variant="body2" color="textSecondary" align="right" component="span">{"h"}</Typography>
             }
-            paper={paper}
         />
-        :
-        <Typography variant="body2" color="textSecondary" align="right">{"2+2 h"}</Typography>
     );
 };

--- a/src/SubjectPreview.js
+++ b/src/SubjectPreview.js
@@ -65,7 +65,21 @@ const SubjectPreview = ({subject}) => {
 };
 
 SubjectPreview.propTypes = {
+    subject: PropTypes.shape({
+        code: PropTypes.string.isRequired,
+        lecturer: PropTypes.string.isRequired,
+        // day: PropTypes.string,  // TODO Number or string?
+        time: PropTypes.string.isRequired,
+        credits: PropTypes.number.isRequired,
+        // length: PropTypes.string.isRequired,  // TODO Number or string? ... "2+2"?
 
+        // TODO Following things are not yet in toy data
+        // name: PropTypes.string.isRequired,
+        // department: PropTypes.string.isRequired,
+        // departmentCode: PropTypes.string.isRequired,
+        // examType: PropTypes.string.isRequired,
+        // annotation: PropTypes.string.isRequired,
+    })
 };
 
 export default SubjectPreview;

--- a/src/SubjectPreview.js
+++ b/src/SubjectPreview.js
@@ -74,6 +74,7 @@ export default SubjectPreview;
 // TODO Probably should move these definitions somewhere else in the future
 const ItemFirstLine = ({subject}) => {
     return (
+        // TODO Put real values here (katedra)
         <Typography variant="body2" gutterBottom>
             <Typography component="span" variant="body2" color="textPrimary">
                 {"18" + subject.code}
@@ -86,8 +87,9 @@ const ItemFirstLine = ({subject}) => {
 
 const ItemExamType = ({subject}) => {
     return (
-        <Box ml={1}>
-            <Typography variant="body2" color="textSecondary" align="center" component="span">{"z zk"}</Typography>
+        // TODO Put real values here (zkouska)
+        <Box textAlign="center">
+            {"z zk"}
         </Box>
     );
 };
@@ -95,6 +97,7 @@ const ItemExamType = ({subject}) => {
 
 const ItemTimetable = ({subject, align="left"}) => {
     return (
+        // TODO Put real values here (rozvrh)
         <Typography variant="body2" align={align} gutterBottom>
             {"Rozvrhováno: "}{formatDay(subject.day)}
             {subject.day === 4 ? ", úterý" : null}
@@ -106,6 +109,7 @@ const ItemTimetable = ({subject, align="left"}) => {
 
 const ItemAnnotation = ({subject}) => {
     return (
+        // TODO Put real values here (anotace)
         <Typography variant="body2" align="justify">
             /anotace/ Lorem ipsum dolor sit amet, consectetur adipiscing elit,
             sed do eiusmod tempor incididunt ut labore et dolore magna
@@ -118,12 +122,13 @@ const ItemAnnotation = ({subject}) => {
 const ItemCredits = ({subject}) => {
     return(
         <QuantityIndicator
+            // TODO Put real values here (kredity, kredity max)
             value={3}
-            maxValue={12}
+            valueMax={12 }
+            label={"15 kr"}
+            labelWidth={"7em"}
             tooltip={"3 kredity"}
-            label={
-                <Typography variant="body2" color="textSecondary" align="right" component="span">{"kr"}</Typography>
-            }
+            color="primary"
         />
     );
 };
@@ -132,14 +137,14 @@ const ItemCredits = ({subject}) => {
 const ItemHours = ({subject}) => {
     return(
         <QuantityIndicator
+            // TODO Put real values here (hodiny, hodiny cvika, hodiny max)
             value={Number(subject.length)}
             valueSecond={2}
-            maxValue={12}
-            color="secondary"
+            valueMax={12}
+            label={"15+15 h"}
+            labelWidth={"7em"}
             tooltip={"2h přednášky + 2h cvičení"}
-            label={
-                <Typography variant="body2" color="textSecondary" align="right" component="span">{"h"}</Typography>
-            }
+            color="secondary"
         />
     );
 };

--- a/src/SubjectPreview.js
+++ b/src/SubjectPreview.js
@@ -12,19 +12,16 @@ import QuantityIndicator from "./QuantityIndicator";
 import {daysInWeek} from "./constants";
 
 
-const formatDay = (day) => {
-    return daysInWeek[day];
-}
-
-
 const useStyles = makeStyles((theme) => ({
     root: {
-        display: "block"
+        display: "block"  // This overrides horizontal layout of ListItem's children
     },
 }));
 
 
-/** Assigned to Jan */
+/**
+ * Displays brief information about the subject organized in a small grid.
+ */
 const SubjectPreview = ({subject}) => {
     const classes = useStyles()
 
@@ -35,39 +32,38 @@ const SubjectPreview = ({subject}) => {
     return (
         <ListItem key={subject.code} className={classes.root}>
             <ListItemText primary={<SubjectDialog subject={subject}/>}/>
-
             <Typography component="div" variant="body2" color="textSecondary">
-            <Grid container spacing={0} justify="space-between">
-                <Grid container item xs={12} sm={9} spacing={1} justify="space-between">
-                    <Grid item xs={10} sm={6}>
-                        <ItemFirstLine subject={subject}/>
+                <Grid container spacing={0} justify="space-between">
+                    <Grid container item xs={12} sm={9} spacing={1} justify="space-between">
+                        <Grid item xs={12} sm={6}>
+                            <ItemFirstLine subject={subject}/>
+                        </Grid>
+                        <Grid item xs={12} sm={6}>
+                            <ItemTimetable subject={subject} align="right"/>
+                        </Grid>
+                        <Grid item xs={12} sm={12}>
+                            <ItemAnnotation subject={subject}/>
+                        </Grid>
                     </Grid>
-                    <Grid item xs={6} sm={6}>
-                        <ItemTimetable subject={subject} align="right"/>
-                    </Grid>
-
-                    <Grid item xs={9} sm={12}>
-                        <ItemAnnotation subject={subject}/>
+                    <Grid container item xs={12} sm={3} spacing={1}>
+                        <Grid item xs={12}>
+                            <ItemExamType subject={subject}/>
+                        </Grid>
+                        <Grid item xs={12}>
+                            <ItemCredits subject={subject} useBar/>
+                        </Grid>
+                        <Grid item xs={12}>
+                            <ItemHours subject={subject} useBar/>
+                        </Grid>
                     </Grid>
                 </Grid>
-                <Grid container item xs={12} sm={3} spacing={1}>
-                    <Grid item xs={12}>
-                        <ItemExamType subject={subject}/>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <ItemCredits subject={subject} useBar/>
-                    </Grid>
-                    <Grid item xs={12}>
-                        <ItemHours subject={subject} useBar/>
-                    </Grid>
-                </Grid>
-            </Grid>
             </Typography>
         </ListItem>
     );
 };
 
 SubjectPreview.propTypes = {
+    /** Data representing 1 subject */
     subject: PropTypes.shape({
         code: PropTypes.string.isRequired,
         lecturer: PropTypes.string.isRequired,
@@ -115,7 +111,7 @@ const ItemExamType = ({subject}) => {
 const ItemTimetable = ({subject, align="left"}) => {
     return (
         <Typography variant="body2" align={align} gutterBottom>
-            {`${formatDay(subject.day)} ${subject.time}`}
+            {`${daysInWeek[subject.day]} ${subject.time}`}
         </Typography>
     );
 };

--- a/src/SubjectPreview.js
+++ b/src/SubjectPreview.js
@@ -8,7 +8,7 @@ import Grid from "@material-ui/core/Grid";
 import Typography from "@material-ui/core/Typography";
 
 import SubjectDialog from "./SubjectDialog";
-import QuantityIndicator from "./QuantityIndicator"
+import QuantityIndicator from "./QuantityIndicator";
 import {daysInWeek} from "./constants";
 
 
@@ -18,7 +18,9 @@ const formatDay = (day) => {
 
 
 const useStyles = makeStyles((theme) => ({
-    root: {},
+    root: {
+        display: "block"
+    },
 }));
 
 
@@ -31,7 +33,7 @@ const SubjectPreview = ({subject}) => {
     subject.day = 0;
 
     return (
-        <ListItem key={subject.code} style={{display: "block"}}>
+        <ListItem key={subject.code} className={classes.root}>
             <ListItemText primary={<SubjectDialog subject={subject}/>}/>
 
             <Typography component="div" variant="body2" color="textSecondary">
@@ -94,7 +96,7 @@ const ItemFirstLine = ({subject}) => {
             <Typography component="span" variant="body2" color="textPrimary">
                 {"18" + subject.code}
             </Typography>
-            {" — " + "KSI" + " — " + subject.lecturer}
+            {` — KSI — ${subject.lecturer}`}
         </Typography>
     );
 };

--- a/src/SubjectPreview.js
+++ b/src/SubjectPreview.js
@@ -27,7 +27,8 @@ const SubjectPreview = ({subject}) => {
     const classes = useStyles()
 
     // TODO Temporary hacks
-    subject.name = "Průmyslový vývoj software"
+    subject.name = "Průmyslový vývoj software";
+    subject.day = 0;
 
     return (
         <ListItem key={subject.code} style={{display: "block"}}>
@@ -68,10 +69,10 @@ SubjectPreview.propTypes = {
     subject: PropTypes.shape({
         code: PropTypes.string.isRequired,
         lecturer: PropTypes.string.isRequired,
-        // day: PropTypes.string,  // TODO Number or string?
+        // day: PropTypes.number,  // TODO Should be number and not english string as it is now (toy data)
         time: PropTypes.string.isRequired,
         credits: PropTypes.number.isRequired,
-        // length: PropTypes.string.isRequired,  // TODO Number or string? ... "2+2"?
+        len: PropTypes.string.isRequired,  // TODO Number or string? ... "2+2"?
 
         // TODO Following things are not yet in toy data
         // name: PropTypes.string.isRequired,
@@ -111,11 +112,8 @@ const ItemExamType = ({subject}) => {
 
 const ItemTimetable = ({subject, align="left"}) => {
     return (
-        // TODO Put real values here (rozvrh)
         <Typography variant="body2" align={align} gutterBottom>
-            {formatDay(subject.day) + " 7:30"}
-            {subject.day === 4 ? ", úterý 17:30" : null}
-            {subject.day === 1 ? ", pátek 18:30" : null}
+            {`${formatDay(subject.day)} ${subject.time}`}
         </Typography>
     );
 };
@@ -136,12 +134,12 @@ const ItemAnnotation = ({subject}) => {
 const ItemCredits = ({subject}) => {
     return(
         <QuantityIndicator
-            // TODO Put real values here (kredity, kredity max)
-            value={3}
-            valueMax={12 }
-            label={"15 kr"}
+            // TODO Put real values here (kredity max)
+            value={Number(subject.credits)}
+            valueMax={12}
+            label={`${subject.credits} kr`}
             labelWidth={"7em"}
-            tooltip={"3 kredity"}
+            tooltip={`${subject.credits} kredity`}
             color="primary"
         />
     );
@@ -151,13 +149,13 @@ const ItemCredits = ({subject}) => {
 const ItemHours = ({subject}) => {
     return(
         <QuantityIndicator
-            // TODO Put real values here (hodiny, hodiny cvika, hodiny max)
-            value={Number(subject.length)}
+            // TODO Put real values here (hodiny cvika, hodiny max)
+            value={Number(subject.len)}
             valueSecond={2}
             valueMax={12}
-            label={"15+15 h"}
+            label={`${subject.len}+? h`}
             labelWidth={"7em"}
-            tooltip={"2h přednášky + 2h cvičení"}
+            tooltip={`${subject.len}h přednášky + ?h cvičení`}
             color="secondary"
         />
     );

--- a/src/SubjectPreview.js
+++ b/src/SubjectPreview.js
@@ -99,9 +99,9 @@ const ItemTimetable = ({subject, align="left"}) => {
     return (
         // TODO Put real values here (rozvrh)
         <Typography variant="body2" align={align} gutterBottom>
-            {"Rozvrhováno: "}{formatDay(subject.day)}
-            {subject.day === 4 ? ", úterý" : null}
-            {subject.day === 1 ? ", pátek" : null}
+            {formatDay(subject.day) + " 7:30"}
+            {subject.day === 4 ? ", úterý 17:30" : null}
+            {subject.day === 1 ? ", pátek 18:30" : null}
         </Typography>
     );
 };

--- a/src/SubjectPreview.test.js
+++ b/src/SubjectPreview.test.js
@@ -13,7 +13,7 @@ test('SubjectPreview renders code', () => {
     time: "11:30",
     day: 0,
     credits: 2,
-    length: "2",
+    len: "2",
   }
   render(<SubjectPreview subject={testSubject} />);
 

--- a/src/SubjectPreview.test.js
+++ b/src/SubjectPreview.test.js
@@ -8,7 +8,20 @@ import SubjectPreview from "./SubjectPreview";
  */
 
 test('SubjectPreview renders code', () => {
-  render(<SubjectPreview subject={{code: "PVS"}} />);
-  const linkElement = screen.getByText(/PVS/i);
+  const testSubject = {
+    length: "2",
+    day: 0,
+    lecturer: "Doubek",
+    code: "PVS",
+  }
+  render(<SubjectPreview subject={testSubject} />);
+
+  let linkElement = screen.getByText(/PVS/i);
+  expect(linkElement).toBeVisible();
+
+  linkElement = screen.getByText(/Doubek/i);
+  expect(linkElement).toBeVisible();
+
+  linkElement = screen.getByText(/pondělí/i);
   expect(linkElement).toBeVisible();
 });

--- a/src/SubjectPreview.test.js
+++ b/src/SubjectPreview.test.js
@@ -2,17 +2,18 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom'
 import SubjectPreview from "./SubjectPreview";
 
-/** Assigned to Jan */
-/** TODO je tady nějaký záhadný error v PropTypes, mám tušení, že je to kvůli SubjectDialog, mát ho asi takhle jako
- * child SubjectPreview je pravděpodobně dost hroznej antipattern a bude se muset pořádně vyřešit
- */
 
+/** Assigned to Jan */
 test('SubjectPreview renders code', () => {
+  // TODO Add more things here as soon as SubjectPreview actually uses the data
   const testSubject = {
-    length: "2",
-    day: 0,
-    lecturer: "Doubek",
     code: "PVS",
+    lecturer: "Doubek",
+
+    time: "11:30",
+    day: 0,
+    credits: 2,
+    length: "2",
   }
   render(<SubjectPreview subject={testSubject} />);
 


### PR DESCRIPTION
Vyčistil jsem kód a vybral tu druhou variantu, pro kterou zatím bylo více lidí. Ale v rámci toho Grid komponentu nebude problém to rychle přeskládat, když bychom to chtěli v budoucnu měnit.

Doplnil jsem další věci, které jsme diskutovali:
- čísla ke kreditům a hodinám
- čas k informacím o rozvrhu (smazal jsem "Rozvrhováno", přišlo mi to nadbytečné a krade to místo)
- větší část dat je tam pořád natvrdo, doplním až nějak budou k dispozici načtené v tom objektu `subject`

Testy:
- testovat by šlo aspoň, že to zobrazuje ty data ze `subject`, tak něco málo jsem tam napsal
- přidal jsem kontrolu typů přes PropTypes

![qwe](https://user-images.githubusercontent.com/50210960/100545910-aa469880-325e-11eb-9d4c-a536907edf47.png)



Closes #23